### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.8
+
+WORKDIR /go/src/shiori
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+CMD ["shiori", "serve"]


### PR DESCRIPTION
Add [Docker](https://www.docker.com/) support. This file will download dependencies and install shiori inside an image. This is extremely useful for server maintainers, because it's secure and easy.

Run `docker build -t shiori .` to build the image
Run `docker run -p 8080:8080 -d --rm --name shiori shiori` to start a docker container
Run `docker exec shiori shiori <COMMAND>` to interact with the container