### PR TITLE
Dockerfile + README.md usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ RUN apk --no-cache add git build-base \
 && go install -v ./... \
 && touch shiori.db
 
+EXPOSE 8080
+
 CMD ["shiori", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.10.0-alpine3.7
+
+WORKDIR /go/src/shiori
+COPY . .
+
+# Install git and gcc
+# Get dependencies
+# Install dependencies
+# Create shiori.db as a file, so in case that the file
+# is mounted with -v, a folder will not be created
+RUN apk --no-cache add git build-base \
+&& go get -d -v ./... \
+&& go install -v ./... \
+&& touch shiori.db
+
+CMD ["shiori", "serve"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,48 @@ Flags:
 Use "shiori [command] --help" for more information about a command.
 ```
 
+## Usage with Docker
+
+There's a Dockerfile that enables you to build your own dockerized Shiori (as by now there is no official image available on Docker Hub).
+
+### Build the image
+
+```bash
+$ docker build -t shiori .
+```
+
+### Run the container
+
+After building the image you will be able to start a container from it;
+
+```bash
+$ docker run -d --name shiori -p 8080:8080 shiori
+```
+
+As after running the container there will be no accounts created, you need to run the following commands:
+
+```bash
+# First open a console to the container (as you will need to enter your password)
+# and the default tty does not support hidden inputs
+$ docker exec -it shiori /bin/sh
+/go/src/shiori # shiori account add <your-desired-username>
+Password: <enter-your-password>
+```
+
+And you're now ready to go and access shiori via web.
+
+> For preserving the database, look at the next section.
+
+### Bind the database
+
+As you've probably noticed, if you dont preserve the database, all your bookmarks will be lost in case of rebooting/rebuilding the container.
+
+To preserve the database you need to bind the file. In this example we're locating the `shiori.db` file in our CWD.
+
+```bash
+$ docker run -d --name shiori -p 8080:8080 -v $(PWD)/shiori.db:/go/src/shiori/shiori.db shiori
+```
+
 ## Examples
 
 1. Save new bookmark with tags "nature" and "climate-change".


### PR DESCRIPTION
This PR adds a Dockerfile that will build Shiori based on the official Go alpine image (by using the alpine version, the resulting image will be smaller).

Comparison between using the standard image (left) vs the Alpine one (right):

![Comparison](https://i.imgur.com/V1EzS60.jpg)

It also adds a little "Usage with Docker" section to the Readme file that will help the users self-host their own shiori containers, with the ability to persist the database across container recreations.