### PR TITLE
add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: go
+sudo: false
+matrix:
+  include:
+    - go: 1.x
+      env: LATEST=true
+    - go: 1.9
+    - go: 1.8
+
+before_install:
+  - go get github.com/mitchellh/gox # go tool for cross compiling
+  - go get github.com/inconshreveable/mousetrap # needed for windows builds
+
+install:
+  - go get github.com/RadhiFadlillah/shiori
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go vet $(go list ./... | grep -v /vendor/)
+  - go test -v -race ./...
+  # only build binaries from the latest Go release.
+  - if [ "${LATEST}" = "true" ]; then gox -os="linux darwin windows" -arch="amd64" -output "shiori_{{.OS}}_{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...; fi
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key:
+    secure: $TOKEN
+  file:
+  - shiori_windows_amd64.exe
+  - shiori_darwin_amd64
+  - shiori_linux_amd64
+  on:
+    tags: true
+    branches:
+      only:
+        - master
+    condition: $LATEST = true


### PR DESCRIPTION
Add the option to deploy releases via Travis CI deployments for linux, osx and windows binaries.

If you haven't used travis before just create an account on https://travis-ci.org/ connect and enable this github repo. Should be self explanatory.
One thing you will have to do is add your `$TOKEN` via travis env variables. You have multiple ways of doing this which you can read [here](https://docs.travis-ci.com/user/environment-variables/)
I used [Defining Variables in Repository Settings](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) in my example.

Once you have configured everything simply tag releases as you did before and travis will create a release on every tagged commit :)

Hopefully this will be of some use :+1: 