### PR TITLE
Prepend environment path to database path

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"os"
+	fp "path/filepath"
 
 	"github.com/RadhiFadlillah/shiori/cmd"
 	db "github.com/RadhiFadlillah/shiori/database"
@@ -12,7 +13,12 @@ import (
 func main() {
 	databasePath := "shiori.db"
 	if value, found := os.LookupEnv("ENV_SHIORI_DB"); found {
-		databasePath = value + "/" + databasePath
+		// If ENV_SHIORI_DB is directory, append "shiori.db" as filename
+		if f1, err := os.Stat(value); err == nil && f1.IsDir() {
+			value = fp.Join(value, "shiori.db")
+		}
+
+		databasePath = value
 	}
 
 	sqliteDB, err := db.OpenSQLiteDatabase(databasePath)

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	databasePath := "shiori.db"
 	if value, found := os.LookupEnv("ENV_SHIORI_DB"); found {
-		databasePath = value
+		databasePath = value + "/" + databasePath
 	}
 
 	sqliteDB, err := db.OpenSQLiteDatabase(databasePath)


### PR DESCRIPTION
This fixes an error when the `ENV_SHIORI_DB` is defined, it doesn't open a database file because the database file name isn't on the `databasePath` variable.