### PR TITLE
Set server timeouts

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -74,7 +74,13 @@ var (
 			port, _ := cmd.Flags().GetInt("port")
 			url := fmt.Sprintf(":%d", port)
 			logrus.Infoln("Serve shiori in", url)
-			logrus.Fatalln(http.ListenAndServe(url, router))
+			svr := &http.Server{
+				Addr:         url,
+				Handler:      router,
+				ReadTimeout:  10 * time.Second,
+				WriteTimeout: 20 * time.Second,
+			}
+			logrus.Fatalln(svr.ListenAndServe())
 		},
 	}
 )


### PR DESCRIPTION
Set server timeouts to avoid leaked descriptors on slow/disappearing clients or slow http attacks.

Fixes #51