### PR TITLE
new pocket command 

### DIFF
--- a/cmd/pocket.go
+++ b/cmd/pocket.go
@@ -71,8 +71,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			offline, _ := cmd.Flags().GetBool("offline")
 			all, _ := cmd.Flags().GetBool("all")
-            tag, _ := cmd.Flags().GetString("tag") 
-
+			tag, _ := cmd.Flags().GetString("tag")
 
 			apikey := viper.Get("pocket.apikey")
 			if apikey == nil {
@@ -95,15 +94,14 @@ var (
 				state = pocketApi.StateAll
 			}
 
-            
 			options := pocketApi.RetrieveOption{
 				DetailType: "complete",
 				State:      state,
 			}
 
-            if tag != "" {
-                options.Tag = tag
-            }   
+			if tag != "" {
+				options.Tag = tag
+			}
 
 			pocketBookmarks, err := client.Retrieve(&options)
 

--- a/cmd/pocket.go
+++ b/cmd/pocket.go
@@ -71,6 +71,8 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			offline, _ := cmd.Flags().GetBool("offline")
 			all, _ := cmd.Flags().GetBool("all")
+            tag, _ := cmd.Flags().GetString("tag") 
+
 
 			apikey := viper.Get("pocket.apikey")
 			if apikey == nil {
@@ -93,10 +95,15 @@ var (
 				state = pocketApi.StateAll
 			}
 
+            
 			options := pocketApi.RetrieveOption{
 				DetailType: "complete",
 				State:      state,
 			}
+
+            if tag != "" {
+                options.Tag = tag
+            }   
 
 			pocketBookmarks, err := client.Retrieve(&options)
 
@@ -189,6 +196,7 @@ func init() {
 
 	importPocketCmd.Flags().BoolP("offline", "o", false, "Import items from pocket without fetching data from internet.")
 	importPocketCmd.Flags().BoolP("all", "a", false, "Import all items from pocket, default is only to import unread items")
+	importPocketCmd.Flags().StringP("tag", "t", "", "Only import items with defined tag")
 	pocketCmd.AddCommand(importPocketCmd)
 
 	rootCmd.AddCommand(pocketCmd)

--- a/cmd/pocket.go
+++ b/cmd/pocket.go
@@ -21,8 +21,8 @@ var (
 		Short: "Manage pocket bookmarks",
 	}
 
-    //requires a consumer key to be set 
-    //https://getpocket.com/developer/docs/authentication
+	//requires a consumer key to be set
+	//https://getpocket.com/developer/docs/authentication
 	setConsumerKeyCmd = &cobra.Command{
 		Use:   "key apikey",
 		Short: "Set consumer key for pocket api",

--- a/cmd/pocket.go
+++ b/cmd/pocket.go
@@ -48,7 +48,6 @@ var (
 			if apikey == nil {
 				cError.Println("Pocket consumer key not set")
 				cError.Println("Please set with: shiori pocket key")
-				fmt.Println("y")
 			}
 			auth, err := obtainPocketAccessToken(apikey.(string))
 			if err != nil {

--- a/cmd/pocket.go
+++ b/cmd/pocket.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/RadhiFadlillah/shiori/model"
+	pocketApi "github.com/motemen/go-pocket/api"
+	pocketAuth "github.com/motemen/go-pocket/auth"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+var (
+	pocketCmd = &cobra.Command{
+		Use:   "pocket",
+		Short: "Manage pocket bookmarks",
+	}
+
+    //requires a consumer key to be set 
+    //https://getpocket.com/developer/docs/authentication
+	setConsumerKeyCmd = &cobra.Command{
+		Use:   "key apikey",
+		Short: "Set consumer key for pocket api",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			apikey := args[0]
+			viper.Set("pocket.apikey", apikey)
+			err := viper.WriteConfigAs(configPath())
+			if err != nil {
+				cError.Println(err)
+				return
+			}
+		},
+	}
+
+	loginPocketCmd = &cobra.Command{
+		Use:   "login username",
+		Short: "Login into pocket",
+		Long: "Login into pocket, this command will use the consumer key set from the command shiori pocket key" +
+			"and attempt to get an access key by providing the user a browser to authorize this action",
+		Run: func(cmd *cobra.Command, args []string) {
+			apikey := viper.Get("pocket.apikey")
+			if apikey == nil {
+				cError.Println("Pocket consumer key not set")
+				cError.Println("Please set with: shiori pocket key")
+				fmt.Println("y")
+			}
+			auth, err := obtainPocketAccessToken(apikey.(string))
+			if err != nil {
+				cError.Println(err)
+				return
+			}
+			viper.Set("pocket.accesstoken", auth.AccessToken)
+			err = viper.WriteConfigAs(configPath())
+			if err != nil {
+				cError.Println(err)
+				return
+			}
+
+			cTitle.Println("Login successful for " + auth.Username)
+		},
+	}
+
+	importPocketCmd = &cobra.Command{
+		Use:   "import",
+		Short: "Import bookmarks from pocket to shiori",
+		Run: func(cmd *cobra.Command, args []string) {
+			offline, _ := cmd.Flags().GetBool("offline")
+			all, _ := cmd.Flags().GetBool("all")
+
+			apikey := viper.Get("pocket.apikey")
+			if apikey == nil {
+				cError.Println("Pocket consumer key not set")
+				cError.Println("Please set with: shiori pocket key")
+				return
+			}
+			accesstoken := viper.Get("pocket.accesstoken")
+			if accesstoken == nil {
+				cError.Println("Pocket access token not set")
+				cError.Println("Please login to pocket: shiori pocket login")
+				return
+			}
+
+			client := pocketApi.NewClient(apikey.(string), accesstoken.(string))
+
+			//set state for retrival from pocket
+			state := pocketApi.StateUnread
+			if all {
+				state = pocketApi.StateAll
+			}
+
+			options := pocketApi.RetrieveOption{
+				DetailType: "complete",
+				State:      state,
+			}
+
+			pocketBookmarks, err := client.Retrieve(&options)
+
+			if err != nil {
+				switch err.(type) {
+				case *json.UnmarshalTypeError:
+					//this usually means that there we no results found
+					cError.Println("Error retrieving results from pocket!\nIt is possible no",
+						"results were found in your unread items, ",
+						"to import all items run command with --all")
+				default:
+					if strings.Contains(err.Error(), "401") {
+						cError.Println("Access token not valid, please relogin with shiori pocket login")
+					} else {
+						//unknown error
+						cError.Println("Error retrieving results from pocket!")
+					}
+				}
+				return
+			}
+
+			currentBookmarks, err := DB.GetBookmarks(false)
+			if err != nil {
+				cError.Println(err)
+				return
+			}
+
+			bMap := make(map[string]string)
+			for _, bmark := range currentBookmarks {
+				url := bmark.URL
+				bMap[url] = ""
+			}
+
+			var found int
+			for _, pmark := range pocketBookmarks.List {
+				//check if bookmark already exists if so do not try to import again
+				if _, ok := bMap[pmark.ResolvedURL]; ok {
+					found++
+					continue
+				}
+
+				var bookmarkTitle string
+
+				//some items added to pocket might not have a user
+				//title set, in this case use the resolved title from the url
+				if pmark.GivenTitle == "" {
+					bookmarkTitle = pmark.ResolvedTitle
+				} else {
+					bookmarkTitle = pmark.GivenTitle
+				}
+
+				bookmark := model.Bookmark{
+					Title:   bookmarkTitle,
+					URL:     pmark.ResolvedURL,
+					Excerpt: pmark.Excerpt,
+				}
+
+				bookmarkTags := []model.Tag{}
+
+				for _, tagM := range pmark.Tags {
+					newTag := model.Tag{
+						Name: tagM["tag"].(string),
+					}
+					bookmarkTags = append(bookmarkTags, newTag)
+				}
+
+				//if pocket item has images use the first image found
+				if len(pmark.Images) > 0 {
+					bookmark.ImageURL = pmark.Images["1"]["src"].(string)
+				}
+
+				bookmark.Tags = bookmarkTags
+				result, err := addBookmark(bookmark, offline)
+				if err != nil {
+					cError.Println(err)
+					return
+				}
+				printBookmark(result)
+			}
+			if found > 0 {
+				cTitle.Printf("%d bookmark(s) have not been imported as they already exist in shiori.\n", found)
+			}
+		},
+	}
+)
+
+func init() {
+	pocketCmd.AddCommand(loginPocketCmd)
+	pocketCmd.AddCommand(setConsumerKeyCmd)
+
+	importPocketCmd.Flags().BoolP("offline", "o", false, "Import items from pocket without fetching data from internet.")
+	importPocketCmd.Flags().BoolP("all", "a", false, "Import all items from pocket, default is only to import unread items")
+	pocketCmd.AddCommand(importPocketCmd)
+
+	rootCmd.AddCommand(pocketCmd)
+}
+
+//https://github.com/motemen/go-pocket/blob/master/cmd/pocket/main.go
+func obtainPocketAccessToken(consumerKey string) (*pocketAuth.Authorization, error) {
+	ch := make(chan struct{})
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.URL.Path == "/favicon.ico" {
+				http.Error(w, "Not Found", 404)
+				return
+			}
+
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintln(w, "Authorized.")
+			ch <- struct{}{}
+		}))
+	defer ts.Close()
+	redirectURL := ts.URL
+
+	requestToken, err := pocketAuth.ObtainRequestToken(consumerKey, redirectURL)
+	if err != nil {
+		return nil, err
+	}
+
+	url := pocketAuth.GenerateAuthorizationURL(requestToken, redirectURL)
+	openbrowser(url)
+	<-ch
+
+	return pocketAuth.ObtainAccessToken(consumerKey, requestToken)
+
+}
+
+//https://gist.github.com/hyg/9c4afcd91fe24316cbf0
+func openbrowser(url string) {
+	var err error
+
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+	if err != nil {
+		cError.Println(err)
+		return
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/RadhiFadlillah/shiori/database"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -20,6 +20,11 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	viper.SetConfigName("config")
+	viper.SetConfigType("json")
+	viper.AddConfigPath(configDir())
+	viper.ReadInConfig()
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -27,4 +28,16 @@ func checkError(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func configDir() string {
+	homeDir, err := homedir.Dir()
+	checkError(err)
+	configDir := homeDir + "/.shiori"
+	return configDir
+}
+
+func configPath() string {
+	configPath := configDir() + "/config.json"
+	return configPath
 }


### PR DESCRIPTION
#29  Added pocket integration using  [https://github.com/motemen/go-pocket](url).

User needs to set a consumer key or create a new one; https://getpocket.com/developer/apps/new

Then can run the following commands 

`shiori pocket key <APIKEY>`
to set the api key

`shiori pocket login` 

The login command will open a browser where the user can login to pocket to authorize the request.

The accesstoken and consumer key are stored in $HOME/.shiori/config.json

Then can run 
`shiori pocket import`
to actually import items from pocket

by default this will not import items that have been archived in pocket, for this run with

`shiori pocket import --all`

If just want to import items with a particular tag can use

`shiori pocket import --tag <TAG>`

Note: the import command imports tags with spaces from pocket although the current web interface is unable to handle these correctly.

